### PR TITLE
Update the config map handling.

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -15,9 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
-
-dependencies:
-- name: cloud-config
-  version: 0.1.0
-  repository: "https://quantcdn.github.io/helm-charts"
+version: 0.3.0

--- a/charts/drupal/templates/app.yaml
+++ b/charts/drupal/templates/app.yaml
@@ -74,7 +74,7 @@ spec:
             timeoutSeconds: 1
           envFrom:
             - configMapRef:
-                name: {{ .Values.configName | default "drupal-config" }}
+                name: "drupal-config-{{ .Values.appEnvironment }}"
           env:
             - name: APACHE_RUN_USER
               value: "nobody"

--- a/charts/drupal/templates/env.yaml
+++ b/charts/drupal/templates/env.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "drupal-config-{{ .Values.appEnvironment }}"
+data:
+    MARIADB_USER: "{{ .Values.secrets.database.username }}"
+    MARIADB_PASSWORD: "{{ .Values.secrets.database.password }}"
+    MARIADB_DATABASE: "{{ .Values.secrets.database.database }}"
+    MARIADB_HOST: "{{ .Values.secrets.database.host }}"
+    MARIADB_PORT: "{{ .Values.secrets.database.port }}"
+    QUANT_SMTP_HOST: "{{ .Values.secrets.smtp.host }}"
+    QUANT_SMTP_PORT: "{{ .Values.secrets.smtp.port }}"
+    QUANT_SMTP_USERNAME: "{{ .Values.secrets.smtp.username }}"
+    QUANT_SMTP_PASSWORD: "{{ .Values.secrets.smtp.password }}"
+    QUANT_SMTP_FROM: "{{ .Values.secrets.smtp.from }}"
+    QUANT_SMTP_FROM_NAME: "{{ .Values.secrets.smtp.from_name }}"
+    REDIS_HOST: "{{ .Values.secrets.redis.host }}"

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -6,7 +6,6 @@ replicaCount: 1
 nameOverride: ""
 fullnameOverride: ""
 productionBranch: main
-configName: drupal-config
 
 images:
   pullPolicy: Always
@@ -109,9 +108,9 @@ ingress:
 # It is recommended to use it with quotes.
 appVersion: "0.1.0"
 
-# Secrets
-# Manage app secrets with kubernetes rather than committing
-# in the codebase itself.
+appEnvironment: main
+
+configName: 
 secrets:
   registry:
     user:


### PR DESCRIPTION
- Add support for `appEnvironment` value
- Always install a config map for the environment that will be named after the environment value

```
# Source: drupal/templates/env.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "drupal-config-test"
```