### PR TITLE
Fix: Remove / location handling.

### DIFF
--- a/charts/drupal-nextjs/Chart.yaml
+++ b/charts/drupal-nextjs/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11

--- a/charts/drupal-nextjs/templates/cm-ingress.yaml
+++ b/charts/drupal-nextjs/templates/cm-ingress.yaml
@@ -13,8 +13,4 @@ data:
     location /themes {
       proxy_pass http://{{ .Values.images.drupal.name }}-$quant_cloud_environment;
     }
-
-    location / {
-      proxy_pass http://{{ .Values.images.nextjs.name }}-$quant_cloud_environment;
-    }
  {{- end }}


### PR DESCRIPTION
- Default nginx configuration defines `/` > `app-default`, this results in a duplicate entry error being raised.